### PR TITLE
Fix missing act fix

### DIFF
--- a/ViewModel/ViewModelMain.cs
+++ b/ViewModel/ViewModelMain.cs
@@ -1202,7 +1202,22 @@ namespace Charrmander.ViewModel
                 {
                     chapterName = chapterName[0..^1];
                 }
-                chapterByNameByActName[actName][chapterName].ChapterCompleted = completed;
+
+                if (actName.Equals("act 1")
+                        && (chapterName.Equals("beneath the canopy")
+                            || chapterName.Equals("ruins of the old world")
+                            || chapterName.Equals("fumbling in the dark")
+                            || chapterName.Equals("path of divinity")))
+                {
+                    actName = "act 2";
+                }
+
+                if (chapterByNameByActName.TryGetValue(actName, out var chapterByName))
+                {
+                    if (chapterByName.TryGetValue(chapterName, out var chapter)) {
+                        chapter.ChapterCompleted = completed;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Loading a character saved by 1.47.0 into 1.49.0 throws a KeyNotFoundException for VoT act 2 story chapters. Migrate those entries to the correct position and make loading more robust.

